### PR TITLE
Reduce char star usage

### DIFF
--- a/ConsoleAdd.cpp
+++ b/ConsoleAdd.cpp
@@ -65,7 +65,7 @@ vector<string> ConsoleAdd::ExtractFilesFromOriginalArchive(const string& archive
 		{
 			try
 			{
-				archive->ExtractFile(i, XFile::AppendSubDirectory(internalFilename, tempDirectory).c_str());
+				archive->ExtractFile(i, XFile::AppendSubDirectory(internalFilename, tempDirectory));
 			}
 			catch (const std::exception& e)
 			{

--- a/ConsoleArgumentParser.h
+++ b/ConsoleArgumentParser.h
@@ -18,13 +18,8 @@ private:
 	{
 		ConsoleSwitch() { }
 
-		ConsoleSwitch(std::string shortSwitch, std::string longSwitch, std::function<void(const char* value, ConsoleArgs&)> parseFunction, int numberOfArgs)
-		{
-			this->shortSwitch = shortSwitch;
-			this->longSwitch = longSwitch;
-			this->parseFunction = parseFunction;
-			this->numberOfArgs = numberOfArgs;
-		}
+		ConsoleSwitch(const std::string& shortSwitch, const std::string& longSwitch, std::function<void(const char* value, ConsoleArgs&)> parseFunction, int numberOfArgs) : 
+			shortSwitch(shortSwitch), longSwitch(longSwitch), parseFunction(parseFunction), numberOfArgs(numberOfArgs) { }
 
 		std::string shortSwitch;
 		std::string longSwitch;

--- a/ConsoleExtract.cpp
+++ b/ConsoleExtract.cpp
@@ -75,8 +75,8 @@ void ConsoleExtract::ExtractSpecificFile(ArchiveFile& archiveFile, const string&
 		XFile::NewDirectory(consoleSettings.destDirectory);
 	}
 
-	string destPath = XFile::ReplaceFilename(consoleSettings.destDirectory, filenameToExtract).c_str();
-	int archiveFileIndex = archiveFile.GetInternalFileIndex(filenameToExtract.c_str());
+	string destPath = XFile::ReplaceFilename(consoleSettings.destDirectory, filenameToExtract);
+	int archiveFileIndex = archiveFile.GetInternalFileIndex(filenameToExtract);
 
 	if (archiveFileIndex == -1) {
 		throw runtime_error("Provided filename does not exist in the archive: " + filenameToExtract + ".");
@@ -89,7 +89,7 @@ void ConsoleExtract::ExtractSpecificFile(ArchiveFile& archiveFile, const string&
 	}
 
 	try {
-		archiveFile.ExtractFile(archiveFileIndex, destPath.c_str());
+		archiveFile.ExtractFile(archiveFileIndex, destPath);
 		if (!consoleSettings.quiet) {
 			cout << filenameToExtract << " extracted." << endl;
 		}

--- a/ConsoleHelper.cpp
+++ b/ConsoleHelper.cpp
@@ -22,11 +22,11 @@ void ConsoleHelper::CheckIfPathsEmpty(const vector<string>& paths)
 unique_ptr<ArchiveFile> ConsoleHelper::OpenArchive(const string& archivePath)
 {
 	if (XFile::ExtensionMatches(archivePath, "VOL")) {
-		return make_unique<VolFile>(archivePath.c_str());
+		return make_unique<VolFile>(archivePath);
 	}
 
 	if (XFile::ExtensionMatches(archivePath, "CLM")) {
-		return make_unique<ClmFile>(archivePath.c_str());
+		return make_unique<ClmFile>(archivePath);
 	}
 
 	throw invalid_argument("Provided filename is not an archive file (.VOL/.CLM)");


### PR DESCRIPTION
Remove unnecessary calls to string::c_str

 - Update to most recent version of OP2Utility

Update struct ConsoleSwitch to use constructor initialization list

 - Pass string arguments into constructor by const reference