### PR TITLE
Update function arguments to pass vectors and strings by reference where appropriate

### DIFF
--- a/ConsoleArgumentParser.h
+++ b/ConsoleArgumentParser.h
@@ -26,7 +26,7 @@ private:
 		std::function<void(const char*, ConsoleArgs&)> parseFunction;
 		int numberOfArgs; // The switch statement itself does not count as an argument.
 
-		bool ArgumentMatch(std::string argument) const
+		bool ArgumentMatch(const std::string& argument) const
 		{
 			return argument == shortSwitch || argument == longSwitch;
 		}

--- a/ConsoleCreate.cpp
+++ b/ConsoleCreate.cpp
@@ -132,7 +132,7 @@ void ConsoleCreate::OutputCreateResults(int packedFileCount, const string& archi
 	}
 }
 
-void ConsoleCreate::CheckForIllegalFilenames(std::vector<std::string> paths)
+void ConsoleCreate::CheckForIllegalFilenames(const std::vector<std::string>& paths)
 {
 	for (const auto& path : paths)
 	{

--- a/ConsoleCreate.h
+++ b/ConsoleCreate.h
@@ -20,5 +20,5 @@ private:
 	void OutputInitialCreateMessage(const std::string& archiveFilename, int packedFileCount);
 	void OutputCreateResults(int packedFileCount, const std::string& archiveFilename);
 
-	void CheckForIllegalFilenames(std::vector<std::string> paths);
+	void CheckForIllegalFilenames(const std::vector<std::string>& paths);
 };

--- a/ConsoleExtract.cpp
+++ b/ConsoleExtract.cpp
@@ -102,7 +102,7 @@ void ConsoleExtract::ExtractSpecificFile(ArchiveFile& archiveFile, const string&
 	}
 }
 
-bool ConsoleExtract::CheckIfFileExists(string path, bool quiet)
+bool ConsoleExtract::CheckIfFileExists(const string& path, bool quiet)
 {
 	if (XFile::PathExists(path))
 	{

--- a/ConsoleExtract.h
+++ b/ConsoleExtract.h
@@ -17,5 +17,5 @@ private:
 	void ExtractAllFiles(Archives::ArchiveFile& archive, const ConsoleSettings& consoleSettings);
 	void ExtractSpecificFile(Archives::ArchiveFile& archive, const std::string& filename, const ConsoleSettings& consoleSettings);
 
-	bool CheckIfFileExists(std::string path, bool quiet);
+	bool CheckIfFileExists(const std::string& path, bool quiet);
 };

--- a/ConsoleRemove.cpp
+++ b/ConsoleRemove.cpp
@@ -50,7 +50,7 @@ vector<string> ConsoleRemove::RemoveMatchingFilenames(ArchiveFile& archive, cons
 	return StringHelper::RemoveStrings(internalFilenames, filesToRemove);
 }
 
-void ConsoleRemove::ThrowUnfoundFileDuringRemoveException(vector<string> unfoundFilenames)
+void ConsoleRemove::ThrowUnfoundFileDuringRemoveException(const vector<string>& unfoundFilenames)
 {
 	string exceptionString("The Following filename(s) were not found in the archive:");
 

--- a/ConsoleRemove.h
+++ b/ConsoleRemove.h
@@ -15,7 +15,7 @@ public:
 private:
 	void OutputInitialAddMessage(const std::string& archiveFilename, int fileCountToRemove);
 	std::vector<std::string> RemoveMatchingFilenames(Archives::ArchiveFile& archive, const std::vector<std::string>& filesToRemove);
-	void ThrowUnfoundFileDuringRemoveException(std::vector<std::string> unfoundFilenames);
+	void ThrowUnfoundFileDuringRemoveException(const std::vector<std::string>& unfoundFilenames);
 	void CheckFilesAvailableToRemove(Archives::ArchiveFile& archive, const std::vector<std::string>& filesToRemove, bool quiet);
 	void ExtractFilesFromOriginalArchive(Archives::ArchiveFile& archive, const std::vector<std::string> internalFilenames);
 };


### PR DESCRIPTION
There is still room for improvement in function arguments in ConsoleArgumentParser that I'm not planning to address at this time as I think it should wait until a larger review of ConsoleArgumentParser occurs. 

Closes #3