### PR TITLE
Update to newer version of OP2Utility

### DIFF
--- a/OP2Archive.vcxproj
+++ b/OP2Archive.vcxproj
@@ -78,7 +78,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>./OP2Utility</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>./OP2Utility; ./OP2Utility/include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <EnablePREfast>false</EnablePREfast>
     </ClCompile>
@@ -125,7 +125,7 @@ if $(ConfigurationName) == Release (
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>./OP2Utility</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>./OP2Utility; ./OP2Utility/include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>

--- a/src/ArchiveConsoleListing.cpp
+++ b/src/ArchiveConsoleListing.cpp
@@ -9,7 +9,7 @@ using namespace Archives;
 
 void ArchiveConsoleListing::ListContents(ArchiveFile& archiveFile)
 {
-	string filename = XFile::GetFilename(archiveFile.GetVolumeFileName());
+	string filename = XFile::GetFilename(archiveFile.GetVolumeFilename());
 
 	if (archiveFile.GetNumberOfPackedFiles() == 0) {
 		cout << filename << " is empty." << endl << endl;
@@ -27,7 +27,7 @@ void ArchiveConsoleListing::ListContents(ArchiveFile& archiveFile)
 
 	for (int i = 0; i < archiveFile.GetNumberOfPackedFiles(); ++i)
 	{
-		string filename(archiveFile.GetInternalFileName(i));
+		string filename(archiveFile.GetInternalFilename(i));
 
 		string filenameBlanks = CreateBlankChars(filename.size(), filenameColumnSize);
 
@@ -50,7 +50,7 @@ int ArchiveConsoleListing::FindMaxFilenameSize(ArchiveFile& archiveFile)
 
 	for (int i = 0; i < archiveFile.GetNumberOfPackedFiles(); ++i)
 	{
-		std::size_t filenameSize = string(archiveFile.GetInternalFileName(i)).size();
+		std::size_t filenameSize = string(archiveFile.GetInternalFilename(i)).size();
 		if (filenameSize > largestFilenameSize && filenameSize <= maxFilenameSize) {
 			largestFilenameSize = filenameSize;
 		}

--- a/src/ConsoleAdd.cpp
+++ b/src/ConsoleAdd.cpp
@@ -53,7 +53,7 @@ vector<string> ConsoleAdd::ExtractFilesFromOriginalArchive(const string& archive
 
 	for (int i = 0; i < archive->GetNumberOfPackedFiles(); ++i)
 	{
-		string internalFilename = archive->GetInternalFileName(i);
+		string internalFilename = archive->GetInternalFilename(i);
 
 		bool taggedForOverwrite = ArchivedFileTaggedForOverwrite(internalFilename, internalFilenames);
 

--- a/src/ConsoleArgumentParser.cpp
+++ b/src/ConsoleArgumentParser.cpp
@@ -1,5 +1,5 @@
 #include "ConsoleArgumentParser.h"
-#include "StringHelper.h"
+#include "OP2Utility.h"
 #include <stdexcept>
 
 using namespace std;

--- a/src/ConsoleCreate.cpp
+++ b/src/ConsoleCreate.cpp
@@ -1,6 +1,6 @@
 #include "ConsoleCreate.h"
 #include "ConsoleHelper.h"
-#include "StringHelper.h"
+#include "OP2Utility.h"
 #include <iostream>
 #include <stdexcept>
 

--- a/src/ConsoleExtract.cpp
+++ b/src/ConsoleExtract.cpp
@@ -57,11 +57,11 @@ void ConsoleExtract::ExtractFromArchive(const string& archiveFilename, const vec
 void ConsoleExtract::ExtractAllFiles(ArchiveFile& archiveFile, const ConsoleSettings& consoleSettings)
 {
 	if (!consoleSettings.quiet) {
-		cout << "Extracting all " << archiveFile.GetNumberOfPackedFiles() << " file(s) from archive " << archiveFile.GetVolumeFileName() << "." << endl;
+		cout << "Extracting all " << archiveFile.GetNumberOfPackedFiles() << " file(s) from archive " << archiveFile.GetVolumeFilename() << "." << endl;
 	}
 
 	for (int i = 0; i < archiveFile.GetNumberOfPackedFiles(); ++i) {
-		ExtractSpecificFile(archiveFile, archiveFile.GetInternalFileName(i), consoleSettings);
+		ExtractSpecificFile(archiveFile, archiveFile.GetInternalFilename(i), consoleSettings);
 	}
 
 	if (!consoleSettings.quiet) {

--- a/src/ConsoleRemove.cpp
+++ b/src/ConsoleRemove.cpp
@@ -44,7 +44,7 @@ vector<string> ConsoleRemove::RemoveMatchingFilenames(ArchiveFile& archive, cons
 	vector<string> internalFilenames;
 
 	for (int i = 0; i < archive.GetNumberOfPackedFiles(); ++i) {
-		internalFilenames.push_back(archive.GetInternalFileName(i));
+		internalFilenames.push_back(archive.GetInternalFilename(i));
 	}
 
 	return StringHelper::RemoveStrings(internalFilenames, filesToRemove);
@@ -73,7 +73,7 @@ void ConsoleRemove::CheckFilesAvailableToRemove(ArchiveFile& archive, const vect
 	vector<string> internalFilenames;
 
 	for (int i = 0; i < archive.GetNumberOfPackedFiles(); ++i) {
-		internalFilenames.push_back(archive.GetInternalFileName(i));
+		internalFilenames.push_back(archive.GetInternalFilename(i));
 	}
 
 	// Unfound filenames are filenames requested for removal that do not exist in the archive.


### PR DESCRIPTION
 - Update calls to OP2Utility's new argument names using filename instead of fileName
 - Remove references to individual headers in OP2Utility and instead use OP2Utility.h