### PR TITLE
Fix MSVC X64 Compile Warnings

### DIFF
--- a/src/ArchiveConsoleListing.cpp
+++ b/src/ArchiveConsoleListing.cpp
@@ -11,23 +11,23 @@ void ArchiveConsoleListing::ListContents(ArchiveFile& archiveFile)
 {
 	string filename = XFile::GetFilename(archiveFile.GetVolumeFilename());
 
-	if (archiveFile.GetNumberOfPackedFiles() == 0) {
+	if (archiveFile.GetCount() == 0) {
 		cout << filename << " is empty." << endl << endl;
 		return;
 	}
 
-	int filenameColumnSize = FindMaxFilenameSize(archiveFile);
+	std::size_t filenameColumnSize = FindMaxFilenameSize(archiveFile);
 
-	cout << "Contents of " << filename << ", " << archiveFile.GetNumberOfPackedFiles() << " file(s)." << endl << endl;
+	cout << "Contents of " << filename << ", " << archiveFile.GetCount() << " file(s)." << endl << endl;
 	cout << "ID  " << "NAME" << string(filenameColumnSize - 4, ' ') << "  SIZE (Bytes)" << endl;
 	cout << "--------------------------------------------------" << endl;
 
 	std::size_t maxCharsInFileSize;
 	unique_ptr<vector<string>> fileSizes = FormatFileSizes(archiveFile, maxCharsInFileSize);
 
-	for (int i = 0; i < archiveFile.GetNumberOfPackedFiles(); ++i)
+	for (std::size_t i = 0; i < archiveFile.GetCount(); ++i)
 	{
-		string filename(archiveFile.GetInternalFilename(i));
+		string filename(archiveFile.GetName(i));
 
 		string filenameBlanks = CreateBlankChars(filename.size(), filenameColumnSize);
 
@@ -44,13 +44,13 @@ void ArchiveConsoleListing::ListContents(ArchiveFile& archiveFile)
 	cout << endl;
 }
 
-int ArchiveConsoleListing::FindMaxFilenameSize(ArchiveFile& archiveFile)
+std::size_t ArchiveConsoleListing::FindMaxFilenameSize(ArchiveFile& archiveFile)
 {
 	std::size_t largestFilenameSize = 0;
 
-	for (int i = 0; i < archiveFile.GetNumberOfPackedFiles(); ++i)
+	for (std::size_t i = 0; i < archiveFile.GetCount(); ++i)
 	{
-		std::size_t filenameSize = string(archiveFile.GetInternalFilename(i)).size();
+		std::size_t filenameSize = string(archiveFile.GetName(i)).size();
 		if (filenameSize > largestFilenameSize && filenameSize <= maxFilenameSize) {
 			largestFilenameSize = filenameSize;
 		}
@@ -67,9 +67,9 @@ unique_ptr<vector<string>> ArchiveConsoleListing::FormatFileSizes(ArchiveFile& a
 	stringstream buffer;
 	buffer.imbue(locale(""));
 
-	for (std::size_t i = 0; i < static_cast<std::size_t>(archiveFile.GetNumberOfPackedFiles()); ++i)
+	for (std::size_t i = 0; i < static_cast<std::size_t>(archiveFile.GetCount()); ++i)
 	{
-		buffer << archiveFile.GetInternalFileSize(i);
+		buffer << archiveFile.GetSize(i);
 
 		fileSizes->push_back(buffer.str());
 
@@ -83,7 +83,7 @@ unique_ptr<vector<string>> ArchiveConsoleListing::FormatFileSizes(ArchiveFile& a
 	return fileSizes;
 }
 
-string ArchiveConsoleListing::CreateBlankChars(std::size_t stringSize, int columnSize)
+string ArchiveConsoleListing::CreateBlankChars(std::size_t stringSize, std::size_t columnSize)
 {
 	std::size_t numberOfBlankChars = 0;
 	if (stringSize <= maxFilenameSize) {

--- a/src/ArchiveConsoleListing.h
+++ b/src/ArchiveConsoleListing.h
@@ -14,7 +14,7 @@ public:
 private:
 	const std::size_t maxFilenameSize = 40;
 	
-	int FindMaxFilenameSize(Archives::ArchiveFile& archiveFile);
+	std::size_t FindMaxFilenameSize(Archives::ArchiveFile& archiveFile);
 	std::unique_ptr<std::vector<std::string>> FormatFileSizes(Archives::ArchiveFile& archiveFile, std::size_t& maxCharsInSize);
-	std::string CreateBlankChars(std::size_t stringSize, int columnSize);
+	std::string CreateBlankChars(std::size_t stringSize, std::size_t columnSize);
 };

--- a/src/ConsoleAdd.cpp
+++ b/src/ConsoleAdd.cpp
@@ -28,7 +28,7 @@ void ConsoleAdd::AddCommand(const ConsoleArgs& consoleArgs)
 	CreateModifiedArchive(archiveFilename, filesToAdd, consoleArgs.consoleSettings.quiet);
 }
 
-void ConsoleAdd::OutputInitialAddMessage(const string& archiveFilename, int fileCountToAdd)
+void ConsoleAdd::OutputInitialAddMessage(const string& archiveFilename, std::size_t fileCountToAdd)
 {
 	cout << "Attempting to add " << fileCountToAdd << " file(s) to the archive " << archiveFilename << endl;
 	cout << ConsoleHelper::dashedLine << endl;
@@ -51,9 +51,9 @@ vector<string> ConsoleAdd::ExtractFilesFromOriginalArchive(const string& archive
 {
 	unique_ptr<ArchiveFile> archive = ConsoleHelper::OpenArchive(archiveFilename);
 
-	for (int i = 0; i < archive->GetNumberOfPackedFiles(); ++i)
+	for (std::size_t i = 0; i < archive->GetCount(); ++i)
 	{
-		string internalFilename = archive->GetInternalFilename(i);
+		string internalFilename = archive->GetName(i);
 
 		bool taggedForOverwrite = ArchivedFileTaggedForOverwrite(internalFilename, internalFilenames);
 

--- a/src/ConsoleAdd.h
+++ b/src/ConsoleAdd.h
@@ -4,6 +4,7 @@
 #include "ConsoleSettings.h"
 #include <string>
 #include <vector>
+#include <cstddef>
 
 class ConsoleAdd : ConsoleModifyBase
 {
@@ -12,7 +13,7 @@ public:
 	void AddCommand(const ConsoleArgs& consoleArgs);
 
 private:
-	void OutputInitialAddMessage(const std::string& archiveFilename, int fileCountToAdd);
+	void OutputInitialAddMessage(const std::string& archiveFilename, std::size_t fileCountToAdd);
 	bool ArchivedFileTaggedForOverwrite(const std::string& internalFilename, const std::vector<std::string>& filesToAdd);
 	std::vector<std::string> ExtractFilesFromOriginalArchive(const std::string& archiveFilename, const std::vector<std::string>& internalFilenames, bool overwrite);
 	void CheckFilesExist(const std::vector<std::string>& filenames);

--- a/src/ConsoleCreate.cpp
+++ b/src/ConsoleCreate.cpp
@@ -114,13 +114,13 @@ void ConsoleCreate::CheckCreateOverwrite(const string& archiveFilename, bool ove
 	}
 }
 
-void ConsoleCreate::OutputInitialCreateMessage(const string& archiveFilename, int packedFileCount)
+void ConsoleCreate::OutputInitialCreateMessage(const string& archiveFilename, std::size_t packedFileCount)
 {
 	cout << "Creating archive " << archiveFilename << ", containing " << packedFileCount << " file(s)." << endl;
 	cout << ConsoleHelper::dashedLine << endl;
 }
 
-void ConsoleCreate::OutputCreateResults(int packedFileCount, const string& archiveFilename)
+void ConsoleCreate::OutputCreateResults(std::size_t packedFileCount, const string& archiveFilename)
 {
 	cout << "Archive created." << endl << endl;
 

--- a/src/ConsoleCreate.h
+++ b/src/ConsoleCreate.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <cstddef>
 
 class ConsoleCreate
 {
@@ -17,8 +18,8 @@ private:
 	void CreateUsingDefaultDirectory(const std::string& archiveFilename, const ConsoleSettings& consoleSettings);
 	std::vector<std::string> GatherFilesForArchive(const std::vector<std::string>& paths);
 	void CheckCreateOverwrite(const std::string& archiveFilename, bool overwrite, bool quiet);
-	void OutputInitialCreateMessage(const std::string& archiveFilename, int packedFileCount);
-	void OutputCreateResults(int packedFileCount, const std::string& archiveFilename);
+	void OutputInitialCreateMessage(const std::string& archiveFilename, std::size_t packedFileCount);
+	void OutputCreateResults(std::size_t packedFileCount, const std::string& archiveFilename);
 
 	void CheckForIllegalFilenames(const std::vector<std::string>& paths);
 };

--- a/src/ConsoleExtract.cpp
+++ b/src/ConsoleExtract.cpp
@@ -57,11 +57,11 @@ void ConsoleExtract::ExtractFromArchive(const string& archiveFilename, const vec
 void ConsoleExtract::ExtractAllFiles(ArchiveFile& archiveFile, const ConsoleSettings& consoleSettings)
 {
 	if (!consoleSettings.quiet) {
-		cout << "Extracting all " << archiveFile.GetNumberOfPackedFiles() << " file(s) from archive " << archiveFile.GetVolumeFilename() << "." << endl;
+		cout << "Extracting all " << archiveFile.GetCount() << " file(s) from archive " << archiveFile.GetVolumeFilename() << "." << endl;
 	}
 
-	for (int i = 0; i < archiveFile.GetNumberOfPackedFiles(); ++i) {
-		ExtractSpecificFile(archiveFile, archiveFile.GetInternalFilename(i), consoleSettings);
+	for (std::size_t i = 0; i < archiveFile.GetCount(); ++i) {
+		ExtractSpecificFile(archiveFile, archiveFile.GetName(i), consoleSettings);
 	}
 
 	if (!consoleSettings.quiet) {

--- a/src/ConsoleRemove.cpp
+++ b/src/ConsoleRemove.cpp
@@ -33,7 +33,7 @@ void ConsoleRemove::RemoveCommand(const ConsoleArgs& consoleArgs)
 	CreateModifiedArchive(archiveFilename, filenames, consoleArgs.consoleSettings.quiet);
 }
 
-void ConsoleRemove::OutputInitialAddMessage(const string& archiveFilename, int fileCountToRemove)
+void ConsoleRemove::OutputInitialAddMessage(const string& archiveFilename, std::size_t fileCountToRemove)
 {
 	cout << "Attempting to remove " << fileCountToRemove << " file(s) from the archive " << archiveFilename << endl;
 	cout << ConsoleHelper::dashedLine << endl;
@@ -43,8 +43,8 @@ vector<string> ConsoleRemove::RemoveMatchingFilenames(ArchiveFile& archive, cons
 {
 	vector<string> internalFilenames;
 
-	for (int i = 0; i < archive.GetNumberOfPackedFiles(); ++i) {
-		internalFilenames.push_back(archive.GetInternalFilename(i));
+	for (std::size_t i = 0; i < archive.GetCount(); ++i) {
+		internalFilenames.push_back(archive.GetName(i));
 	}
 
 	return StringHelper::RemoveStrings(internalFilenames, filesToRemove);
@@ -72,8 +72,8 @@ void ConsoleRemove::CheckFilesAvailableToRemove(ArchiveFile& archive, const vect
 {
 	vector<string> internalFilenames;
 
-	for (int i = 0; i < archive.GetNumberOfPackedFiles(); ++i) {
-		internalFilenames.push_back(archive.GetInternalFilename(i));
+	for (std::size_t i = 0; i < archive.GetCount(); ++i) {
+		internalFilenames.push_back(archive.GetName(i));
 	}
 
 	// Unfound filenames are filenames requested for removal that do not exist in the archive.
@@ -89,7 +89,8 @@ void ConsoleRemove::ExtractFilesFromOriginalArchive(ArchiveFile& archive, const 
 {
 	for (const auto& internalFilename : internalFilenames)
 	{
-		int index = archive.GetInternalFileIndex(internalFilename);
+		std::size_t index = archive.GetIndex(internalFilename);
+
 		string pathToExtractTo = XFile::AppendSubDirectory(internalFilename, tempDirectory);
 
 		try {

--- a/src/ConsoleRemove.h
+++ b/src/ConsoleRemove.h
@@ -5,6 +5,7 @@
 #include "OP2Utility.h"
 #include <vector>
 #include <string>
+#include <cstddef>
 
 class ConsoleRemove : ConsoleModifyBase
 {
@@ -13,7 +14,7 @@ public:
 	void RemoveCommand(const ConsoleArgs& consoleArgs);
 
 private:
-	void OutputInitialAddMessage(const std::string& archiveFilename, int fileCountToRemove);
+	void OutputInitialAddMessage(const std::string& archiveFilename, std::size_t fileCountToRemove);
 	std::vector<std::string> RemoveMatchingFilenames(Archives::ArchiveFile& archive, const std::vector<std::string>& filesToRemove);
 	void ThrowUnfoundFileDuringRemoveException(const std::vector<std::string>& unfoundFilenames);
 	void CheckFilesAvailableToRemove(Archives::ArchiveFile& archive, const std::vector<std::string>& filesToRemove, bool quiet);


### PR DESCRIPTION
 - Update to newest version of OP2Utility API

I thought about trying to seperate out the OP2Utility API changes from fixing the MSVC X64 compile warnings. However, several of the API changes dealt with updating function variable arguments and returns to be of type size_t, so I thought it was better to do both at once.

-Brett