### PR TITLE
Fix makefile sub-project dependency update check

### DIFF
--- a/makefile
+++ b/makefile
@@ -36,7 +36,10 @@ $(OUTPUT): $(UTILITYLIB) $(OBJS)
 	@mkdir -p ${@D}
 	$(CXX) $^ $(LDFLAGS) -o $@ $(LDLIBS)
 
-$(UTILITYLIB):
+$(UTILITYLIB): op2utility
+
+.PHONY:op2utility
+op2utility:
 	$(MAKE) -C $(UTILITYDIR)
 
 $(OBJS): $(OBJDIR)/%.o : $(SRCDIR)/%.cpp $(DEPDIR)/%.d | build-folder


### PR DESCRIPTION
Previously, the sub-project would not always be rebuilt when changes
where made. This could result in linking errors in the parent project
for newly added methods of the subproject.

This change also makes it easier to explicitly compile the subproject.