### PR TITLE
Switch to order only dependency for Makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -32,11 +32,9 @@ FOLDERS := $(sort $(dir $(SRCS)))
 
 all: $(OUTPUT)
 
-$(OUTPUT): $(UTILITYLIB) $(OBJS)
+$(OUTPUT): $(OBJS) | op2utility
 	@mkdir -p ${@D}
 	$(CXX) $^ $(LDFLAGS) -o $@ $(LDLIBS)
-
-$(UTILITYLIB): op2utility
 
 .PHONY:op2utility
 op2utility:


### PR DESCRIPTION
Change copied from OP2MapImager project: commit 2bc3630

https://github.com/OutpostUniverse/OP2MapImager/pull/40/commits/2bc3630592a1cfaf22c3e009b6a5b5e347eeb645