### PR TITLE
Cleanup makefile `.PHONY` rules

### DIFF
--- a/makefile
+++ b/makefile
@@ -36,7 +36,7 @@ $(OUTPUT): $(OBJS) | op2utility
 	@mkdir -p ${@D}
 	$(CXX) $^ $(LDFLAGS) -o $@ $(LDLIBS)
 
-.PHONY:op2utility
+.PHONY: op2utility
 op2utility:
 	$(MAKE) -C $(UTILITYDIR)
 
@@ -44,7 +44,7 @@ $(OBJS): $(OBJDIR)/%.o : $(SRCDIR)/%.cpp $(DEPDIR)/%.d | build-folder
 	$(COMPILE.cpp) $(OUTPUT_OPTION) $<
 	$(POSTCOMPILE)
 
-.PHONY:build-folder
+.PHONY: build-folder
 build-folder:
 	@mkdir -p $(patsubst $(SRCDIR)/%,$(OBJDIR)/%, $(FOLDERS))
 	@mkdir -p $(patsubst $(SRCDIR)/%,$(DEPDIR)/%, $(FOLDERS))
@@ -54,7 +54,7 @@ $(DEPDIR)/%.d: ;
 
 include $(wildcard $(patsubst $(SRCDIR)/%.cpp,$(DEPDIR)/%.d,$(SRCS)))
 
-.PHONY:clean, clean-deps, clean-all
+.PHONY: clean clean-deps clean-all
 clean:
 	-rm -fr $(OBJDIR)
 	-rm -fr $(DEPDIR)
@@ -65,6 +65,6 @@ clean-all:
 	-rm -rf $(BUILDDIR)
 
 
-.PHONY:check
+.PHONY: check
 check:
 	@echo "No tests to run"


### PR DESCRIPTION
Lists should be space separated, not comma separated.

Linux only change.
