### PR TITLE
Remove Clang as default compiler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,5 +6,5 @@ jobs:
     steps:
       - checkout
       - run: git submodule update --init
-      - run: make -k CXX=g++
-      - run: make check CXX=g++
+      - run: make -k
+      - run: make check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,5 +6,5 @@ jobs:
     steps:
       - checkout
       - run: git submodule update --init
-      - run: make -k
+      - run: make --keep-going
       - run: make check

--- a/makefile
+++ b/makefile
@@ -1,11 +1,4 @@
 
-# Set compiler default
-# Can still override from command line or environment variables
-# Example: make CXX=clang
-ifeq ($(origin CXX),default)
-	CXX := clang-6.0
-endif
-
 SRCDIR := src
 BUILDDIR := .build
 BINDIR := $(BUILDDIR)/bin


### PR DESCRIPTION
Specifying the default like that was probably bad practice. That's especially true of the explicit and now dated version that was specified.

Code should now build with the environment default compiler, which is typically GCC. It can be modified by the CXX environment variable. This can be done directly in the make command.

Example:
```
make CXX=g++
```

Example:
```
make CXX=clang++
```