### PR TITLE
Use OP2Utility namespace

### DIFF
--- a/OP2Archive.vcxproj
+++ b/OP2Archive.vcxproj
@@ -80,6 +80,7 @@
       <AdditionalIncludeDirectories>./OP2Utility; ./OP2Utility/include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <EnablePREfast>false</EnablePREfast>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <PostBuildEvent>
       <Command>SET zipName="OP2Archive Ver1.2.2 "$(Platform)
@@ -119,6 +120,7 @@ if $(ConfigurationName) == Release (
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>./OP2Utility; ./OP2Utility/include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <PostBuildEvent>
       <Command>SET zipName="OP2Archive Ver1.2.2 "$(Platform)
@@ -160,6 +162,7 @@ if $(ConfigurationName) == Release (
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>./OP2Utility; ./OP2Utility/include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
@@ -203,6 +206,7 @@ if $(ConfigurationName) == Release (
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>./OP2Utility; ./OP2Utility/include</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/src/ArchiveConsoleListing.cpp
+++ b/src/ArchiveConsoleListing.cpp
@@ -9,7 +9,7 @@ using namespace Archive;
 
 void ArchiveConsoleListing::ListContents(ArchiveFile& archiveFile)
 {
-	string filename = XFile::GetFilename(archiveFile.GetArchiveFilename());
+	auto filename = XFile::GetFilename(archiveFile.GetArchiveFilename());
 
 	if (archiveFile.GetCount() == 0) {
 		cout << filename << " is empty." << endl << endl;

--- a/src/ArchiveConsoleListing.cpp
+++ b/src/ArchiveConsoleListing.cpp
@@ -5,11 +5,11 @@
 #include <sstream>
 
 using namespace std;
-using namespace Archive;
+using namespace OP2Utility::Archive;
 
 void ArchiveConsoleListing::ListContents(ArchiveFile& archiveFile)
 {
-	auto filename = XFile::GetFilename(archiveFile.GetArchiveFilename());
+	auto filename = OP2Utility::XFile::GetFilename(archiveFile.GetArchiveFilename());
 
 	if (archiveFile.GetCount() == 0) {
 		cout << filename << " is empty." << endl << endl;

--- a/src/ArchiveConsoleListing.h
+++ b/src/ArchiveConsoleListing.h
@@ -9,12 +9,12 @@
 class ArchiveConsoleListing
 {
 public:
-	void ListContents(Archive::ArchiveFile& archiveFile);
+	void ListContents(OP2Utility::Archive::ArchiveFile& archiveFile);
 
 private:
 	const std::size_t maxFilenameSize = 40;
 	
-	std::size_t FindMaxFilenameSize(Archive::ArchiveFile& archiveFile);
-	std::unique_ptr<std::vector<std::string>> FormatFileSizes(Archive::ArchiveFile& archiveFile, std::size_t& maxCharsInSize);
+	std::size_t FindMaxFilenameSize(OP2Utility::Archive::ArchiveFile& archiveFile);
+	std::unique_ptr<std::vector<std::string>> FormatFileSizes(OP2Utility::Archive::ArchiveFile& archiveFile, std::size_t& maxCharsInSize);
 	std::string CreateBlankChars(std::size_t stringSize, std::size_t columnSize);
 };

--- a/src/ConsoleAdd.cpp
+++ b/src/ConsoleAdd.cpp
@@ -53,7 +53,7 @@ vector<string> ConsoleAdd::ExtractFilesFromOriginalArchive(const string& archive
 
 	for (std::size_t i = 0; i < archive->GetCount(); ++i)
 	{
-		string internalFilename = archive->GetName(i);
+		auto internalFilename = archive->GetName(i);
 
 		bool taggedForOverwrite = ArchivedFileTaggedForOverwrite(internalFilename, internalFilenames);
 

--- a/src/ConsoleAdd.cpp
+++ b/src/ConsoleAdd.cpp
@@ -7,7 +7,8 @@
 #include <stdexcept>
 
 using namespace std;
-using namespace Archive;
+using namespace OP2Utility;
+using namespace OP2Utility::Archive;
 
 void ConsoleAdd::AddCommand(const ConsoleArgs& consoleArgs)
 {

--- a/src/ConsoleArgumentParser.cpp
+++ b/src/ConsoleArgumentParser.cpp
@@ -3,7 +3,7 @@
 #include <stdexcept>
 
 using namespace std;
-using namespace Archive;
+using namespace OP2Utility::Archive;
 
 ConsoleArgumentParser::ConsoleArgumentParser() 
 {
@@ -17,7 +17,7 @@ ConsoleArgumentParser::ConsoleArgumentParser()
 
 bool ConsoleArgumentParser::FindSwitch(char* argumentChar, ConsoleSwitch& currentSwitch)
 {
-	string argument = StringHelper::ConvertToUpper(argumentChar);
+	auto argument = OP2Utility::StringUtility::ConvertToUpper(argumentChar);
 
 	// Remove trailing colon from switch statements.
 	if (argument.size() > 0 && argument[argument.size() - 1] == ':') {
@@ -56,7 +56,7 @@ ConsoleArgs ConsoleArgumentParser::SortArguments(int argc, char **argv)
 
 ConsoleCommand ConsoleArgumentParser::ParseCommand(const string& commandStr)
 {
-	string commandStrUpper = StringHelper::ConvertToUpper(commandStr);
+	auto commandStrUpper = OP2Utility::StringUtility::ConvertToUpper(commandStr);
 
 	// Allow detection of help switch in command slot position
 	if (commandStrUpper == "--HELP" || commandStrUpper == "-?" || commandStrUpper == "-H") {
@@ -110,7 +110,7 @@ void ConsoleArgumentParser::ParseArgument(char** argv, int& i, int argc, Console
 
 CompressionType ConsoleArgumentParser::ParseCompression(const string& compressionStr)
 {
-	string compressionStrUpper = StringHelper::ConvertToUpper(compressionStr);
+	auto compressionStrUpper = OP2Utility::StringUtility::ConvertToUpper(compressionStr);
 
 	if (compressionStrUpper == "NONE" || compressionStrUpper == "UNCOMPRESSED") {
 		return Archive::CompressionType::Uncompressed;
@@ -130,7 +130,7 @@ CompressionType ConsoleArgumentParser::ParseCompression(const string& compressio
 
 bool ConsoleArgumentParser::ParseBool(const string& str)
 {
-	string upperStr = StringHelper::ConvertToUpper(str);
+	auto upperStr = OP2Utility::StringUtility::ConvertToUpper(str);
 
 	if (upperStr == "TRUE" || upperStr == "YES") {
 		return true;

--- a/src/ConsoleArgumentParser.cpp
+++ b/src/ConsoleArgumentParser.cpp
@@ -113,16 +113,16 @@ CompressionType ConsoleArgumentParser::ParseCompression(const string& compressio
 	auto compressionStrUpper = OP2Utility::StringUtility::ConvertToUpper(compressionStr);
 
 	if (compressionStrUpper == "NONE" || compressionStrUpper == "UNCOMPRESSED") {
-		return Archive::CompressionType::Uncompressed;
+		return CompressionType::Uncompressed;
 	}
 	if (compressionStrUpper == "LZ") {
-		return Archive::CompressionType::LZ;
+		return CompressionType::LZ;
 	}
 	if (compressionStrUpper == "LZH") {
-		return Archive::CompressionType::LZH;
+		return CompressionType::LZH;
 	}
 	if (compressionStrUpper == "RLE") {
-		return Archive::CompressionType::RLE;
+		return CompressionType::RLE;
 	}
 
 	throw invalid_argument("Unable to determine compression type. Try None, LZ, LZH, or RLE.");

--- a/src/ConsoleArgumentParser.h
+++ b/src/ConsoleArgumentParser.h
@@ -47,6 +47,6 @@ private:
 	static void ParseOverwrite(const char* value, ConsoleArgs& consoleArgs);
 	static void ParseCompressionFormat(const char* value, ConsoleArgs& consoleArgs);
 
-	static Archive::CompressionType ParseCompression(const std::string& compressionStr);
+	static OP2Utility::Archive::CompressionType ParseCompression(const std::string& compressionStr);
 	static bool ParseBool(const std::string& str);
 };

--- a/src/ConsoleCreate.cpp
+++ b/src/ConsoleCreate.cpp
@@ -124,7 +124,7 @@ void ConsoleCreate::CheckForIllegalFilenames(const std::vector<std::string>& pat
 {
 	for (const auto& path : paths)
 	{
-		std::string filename = XFile::GetFilename(path);
+		auto filename = XFile::GetFilename(path);
 
 		if (StringHelper::ContainsNonAsciiChars(filename)) {
 			throw std::runtime_error("The following filename contains an illegal character and cannot be packed: " + filename + ".");

--- a/src/ConsoleCreate.cpp
+++ b/src/ConsoleCreate.cpp
@@ -126,7 +126,7 @@ void ConsoleCreate::CheckForIllegalFilenames(const std::vector<std::string>& pat
 	{
 		auto filename = XFile::GetFilename(path);
 
-		if (StringHelper::ContainsNonAsciiChars(filename)) {
+		if (StringUtility::ContainsNonAsciiChars(filename)) {
 			throw std::runtime_error("The following filename contains an illegal character and cannot be packed: " + filename + ".");
 		}
 	}

--- a/src/ConsoleCreate.cpp
+++ b/src/ConsoleCreate.cpp
@@ -5,7 +5,8 @@
 #include <stdexcept>
 
 using namespace std;
-using namespace Archive;
+using namespace OP2Utility;
+using namespace OP2Utility::Archive;
 
 void ConsoleCreate::CreateCommand(const ConsoleArgs& consoleArgs)
 {

--- a/src/ConsoleCreate.h
+++ b/src/ConsoleCreate.h
@@ -14,7 +14,7 @@ public:
 	void CreateArchiveFile(const std::string& archiveFilename, const std::vector<std::string>& filenames, bool quiet);
 
 private:
-	std::unique_ptr<Archive::ArchiveFile> CreateArchiveTemplate(const std::string& archiveFilename);
+	std::unique_ptr<OP2Utility::Archive::ArchiveFile> CreateArchiveTemplate(const std::string& archiveFilename);
 	std::vector<std::string> GatherFilesForArchive(const std::vector<std::string>& paths);
 	void CheckCreateOverwrite(const std::string& archiveFilename, bool overwrite, bool quiet);
 	void OutputInitialCreateMessage(const std::string& archiveFilename, std::size_t packedFileCount);

--- a/src/ConsoleExtract.cpp
+++ b/src/ConsoleExtract.cpp
@@ -5,7 +5,8 @@
 #include <memory>
 
 using namespace std;
-using namespace Archive;
+using namespace OP2Utility;
+using namespace OP2Utility::Archive;
 
 void ConsoleExtract::ExtractCommand(const ConsoleArgs& consoleArgs)
 {

--- a/src/ConsoleExtract.cpp
+++ b/src/ConsoleExtract.cpp
@@ -28,11 +28,11 @@ void ConsoleExtract::ExtractCommand(const ConsoleArgs& consoleArgs)
 
 void ConsoleExtract::ExtractFromDirectory(const string& directory, const ConsoleSettings& consoleSettings)
 {
-	vector<string> archiveFilenames = ConsoleHelper::GetArchiveFilenames(directory);
+	auto archiveFilenames = ConsoleHelper::GetArchiveFilenames(directory);
 
 	for (const auto& archiveFilename : archiveFilenames)
 	{
-		const string archivePath = XFile::Append(directory, archiveFilename);
+		const auto archivePath = XFile::Append(directory, archiveFilename);
 		unique_ptr<ArchiveFile> archive = ConsoleHelper::OpenArchive(archivePath);
 		ExtractAllFiles(*archive, consoleSettings);
 	}
@@ -75,7 +75,7 @@ void ConsoleExtract::ExtractSpecificFile(ArchiveFile& archiveFile, const string&
 		XFile::NewDirectory(consoleSettings.destDirectory);
 	}
 
-	string destPath = XFile::Append(consoleSettings.destDirectory, filenameToExtract);
+	auto destPath = XFile::Append(consoleSettings.destDirectory, filenameToExtract);
 
 	if (!consoleSettings.overwrite) {
 		if (CheckIfFileExists(destPath, consoleSettings.quiet)) {

--- a/src/ConsoleExtract.h
+++ b/src/ConsoleExtract.h
@@ -14,8 +14,8 @@ private:
 	void ExtractFromArchive(const std::string& archiveFilename, const std::vector<std::string>& filesToExtract, const ConsoleSettings& consoleSettings);
 	void ExtractFromDirectory(const std::string& directory, const ConsoleSettings& consoleSettings);
 
-	void ExtractAllFiles(Archive::ArchiveFile& archive, const ConsoleSettings& consoleSettings);
-	void ExtractSpecificFile(Archive::ArchiveFile& archive, const std::string& filename, const ConsoleSettings& consoleSettings);
+	void ExtractAllFiles(OP2Utility::Archive::ArchiveFile& archive, const ConsoleSettings& consoleSettings);
+	void ExtractSpecificFile(OP2Utility::Archive::ArchiveFile& archive, const std::string& filename, const ConsoleSettings& consoleSettings);
 
 	bool CheckIfFileExists(const std::string& path, bool quiet);
 };

--- a/src/ConsoleFind.cpp
+++ b/src/ConsoleFind.cpp
@@ -17,9 +17,9 @@ void ConsoleFind::FindFileInArchives(const string& path)
 {
 	ResourceManager resourceManager(XFile::GetDirectory(path));
 
-	const string filename = XFile::GetFilename(path);
+	const auto filename = XFile::GetFilename(path);
 
-	const string archiveFilename = resourceManager.FindContainingArchivePath(filename);
+	const auto archiveFilename = resourceManager.FindContainingArchivePath(filename);
 
 	if (archiveFilename == "") {
 		cout << "The file " << filename << " is not located in an archive at the supplied directory." << endl << endl;

--- a/src/ConsoleFind.cpp
+++ b/src/ConsoleFind.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 
 using namespace std;
+using namespace OP2Utility;
 
 void ConsoleFind::FindCommand(const ConsoleArgs& consoleArgs)
 {

--- a/src/ConsoleHelper.cpp
+++ b/src/ConsoleHelper.cpp
@@ -34,8 +34,8 @@ unique_ptr<ArchiveFile> ConsoleHelper::OpenArchive(const string& archivePath)
 
 vector<string> ConsoleHelper::GetArchiveFilenames(const string& directory)
 {
-	vector<string> archiveFilenames = XFile::DirFilesWithExtension(directory, ".vol");
-	vector<string> clmFilenames = XFile::DirFilesWithExtension(directory, ".clm");
+	auto archiveFilenames = XFile::DirFilesWithExtension(directory, ".vol");
+	auto clmFilenames = XFile::DirFilesWithExtension(directory, ".clm");
 
 	archiveFilenames.insert(std::end(archiveFilenames), std::begin(clmFilenames), std::end(clmFilenames));
 

--- a/src/ConsoleHelper.cpp
+++ b/src/ConsoleHelper.cpp
@@ -3,7 +3,8 @@
 #include <stdexcept>
 
 using namespace std;
-using namespace Archive;
+using namespace OP2Utility;
+using namespace OP2Utility::Archive;
 
 const string ConsoleHelper::dashedLine = "--------------------------------------------------";
 

--- a/src/ConsoleHelper.h
+++ b/src/ConsoleHelper.h
@@ -11,7 +11,7 @@ public:
 	static const std::string dashedLine;
 
 	static bool IsArchiveExtension(const std::string& filename);
-	static std::unique_ptr<Archive::ArchiveFile> OpenArchive(const std::string& archivePath);
+	static std::unique_ptr<OP2Utility::Archive::ArchiveFile> OpenArchive(const std::string& archivePath);
 	static std::vector<std::string> GetArchiveFilenames(const std::string& directory);
 	static void CheckIfPathsEmpty(const std::vector<std::string>& paths);
 	static std::string CreateTempDirectory();

--- a/src/ConsoleList.cpp
+++ b/src/ConsoleList.cpp
@@ -6,7 +6,7 @@
 #include <stdexcept>
 
 using namespace std;
-using namespace Archive;
+using namespace OP2Utility::Archive;
 
 void ConsoleList::ListCommand(const ConsoleArgs& consoleArgs)
 {
@@ -14,7 +14,7 @@ void ConsoleList::ListCommand(const ConsoleArgs& consoleArgs)
 
 	for (const auto& path : consoleArgs.paths)
 	{
-		if (XFile::IsDirectory(path)) {
+		if (OP2Utility::XFile::IsDirectory(path)) {
 			ListAllArchivesInDirectory(path);
 		}
 		else if (ConsoleHelper::IsArchiveExtension(path)) {
@@ -40,6 +40,6 @@ void ConsoleList::ListAllArchivesInDirectory(const string& directory)
 	cout << ConsoleHelper::dashedLine << endl << endl;
 
 	for (const auto& filename : archiveFilenames) {
-		ListArchiveContents(XFile::Append(directory, filename));
+		ListArchiveContents(OP2Utility::XFile::Append(directory, filename));
 	}
 }

--- a/src/ConsoleModifyBase.cpp
+++ b/src/ConsoleModifyBase.cpp
@@ -17,7 +17,7 @@ ConsoleModifyBase::ConsoleModifyBase(const string& successMessage)
 ConsoleModifyBase::~ConsoleModifyBase()
 {
 	if (!tempDirectory.empty()) {
-		XFile::DeletePath(tempDirectory);
+		OP2Utility::XFile::DeletePath(tempDirectory);
 	}
 }
 

--- a/src/ConsoleRemove.cpp
+++ b/src/ConsoleRemove.cpp
@@ -7,7 +7,8 @@
 #include <stdexcept>
 
 using namespace std;
-using namespace Archive;
+using namespace OP2Utility;
+using namespace OP2Utility::Archive;
 
 void ConsoleRemove::RemoveCommand(const ConsoleArgs& consoleArgs)
 {

--- a/src/ConsoleRemove.cpp
+++ b/src/ConsoleRemove.cpp
@@ -11,8 +11,8 @@ using namespace Archive;
 
 void ConsoleRemove::RemoveCommand(const ConsoleArgs& consoleArgs)
 {
-	string archiveFilename = GetArchiveName(consoleArgs);
-	vector<string> filesToRemove = GetFilesToModify(consoleArgs);
+	auto archiveFilename = GetArchiveName(consoleArgs);
+	auto filesToRemove = GetFilesToModify(consoleArgs);
 	
 	if (!consoleArgs.consoleSettings.quiet) {
 		OutputInitialAddMessage(archiveFilename, filesToRemove.size());
@@ -28,7 +28,7 @@ void ConsoleRemove::RemoveCommand(const ConsoleArgs& consoleArgs)
 
 	archive.reset();
 
-	vector<string> filenames = XFile::DirFiles(tempDirectory);
+	auto filenames = XFile::DirFiles(tempDirectory);
 
 	for (auto& filename : filenames) {
 		filename = XFile::Append(tempDirectory, filename);
@@ -81,7 +81,7 @@ void ConsoleRemove::CheckFilesAvailableToRemove(ArchiveFile& archive, const vect
 	}
 
 	// Unfound filenames are filenames requested for removal that do not exist in the archive.
-	vector<string> unfoundFilenames = StringHelper::RemoveStrings(filesToRemove, internalFilenames);
+	auto unfoundFilenames = StringHelper::RemoveStrings(filesToRemove, internalFilenames);
 
 	if (unfoundFilenames.size() > 0) {
 		ThrowUnfoundFileDuringRemoveException(unfoundFilenames);
@@ -93,9 +93,9 @@ void ConsoleRemove::ExtractFilesFromOriginalArchive(ArchiveFile& archive, const 
 {
 	for (const auto& internalFilename : internalFilenames)
 	{
-		std::size_t index = archive.GetIndex(internalFilename);
+		auto index = archive.GetIndex(internalFilename);
 
-		string pathToExtractTo = XFile::AppendSubDirectory(internalFilename, tempDirectory);
+		auto pathToExtractTo = XFile::AppendSubDirectory(internalFilename, tempDirectory);
 
 		try {
 			archive.ExtractFile(index, pathToExtractTo);

--- a/src/ConsoleRemove.cpp
+++ b/src/ConsoleRemove.cpp
@@ -51,7 +51,7 @@ vector<string> ConsoleRemove::RemoveMatchingFilenames(ArchiveFile& archive, cons
 		internalFilenames.push_back(archive.GetName(i));
 	}
 
-	return StringHelper::RemoveStrings(internalFilenames, filesToRemove);
+	return StringUtility::RemoveStrings(internalFilenames, filesToRemove);
 }
 
 void ConsoleRemove::ThrowUnfoundFileDuringRemoveException(const vector<string>& unfoundFilenames)
@@ -81,7 +81,7 @@ void ConsoleRemove::CheckFilesAvailableToRemove(ArchiveFile& archive, const vect
 	}
 
 	// Unfound filenames are filenames requested for removal that do not exist in the archive.
-	auto unfoundFilenames = StringHelper::RemoveStrings(filesToRemove, internalFilenames);
+	auto unfoundFilenames = StringUtility::RemoveStrings(filesToRemove, internalFilenames);
 
 	if (unfoundFilenames.size() > 0) {
 		ThrowUnfoundFileDuringRemoveException(unfoundFilenames);

--- a/src/ConsoleRemove.h
+++ b/src/ConsoleRemove.h
@@ -15,8 +15,8 @@ public:
 
 private:
 	void OutputInitialAddMessage(const std::string& archiveFilename, std::size_t fileCountToRemove);
-	std::vector<std::string> RemoveMatchingFilenames(Archive::ArchiveFile& archive, const std::vector<std::string>& filesToRemove);
+	std::vector<std::string> RemoveMatchingFilenames(OP2Utility::Archive::ArchiveFile& archive, const std::vector<std::string>& filesToRemove);
 	void ThrowUnfoundFileDuringRemoveException(const std::vector<std::string>& unfoundFilenames);
-	void CheckFilesAvailableToRemove(Archive::ArchiveFile& archive, const std::vector<std::string>& filesToRemove, bool quiet);
-	void ExtractFilesFromOriginalArchive(Archive::ArchiveFile& archive, const std::vector<std::string> internalFilenames);
+	void CheckFilesAvailableToRemove(OP2Utility::Archive::ArchiveFile& archive, const std::vector<std::string>& filesToRemove, bool quiet);
+	void ExtractFilesFromOriginalArchive(OP2Utility::Archive::ArchiveFile& archive, const std::vector<std::string> internalFilenames);
 };

--- a/src/ConsoleSettings.h
+++ b/src/ConsoleSettings.h
@@ -10,7 +10,7 @@ struct ConsoleSettings
 	bool overwrite = false;
 	bool quiet = false;
 	bool helpRequested = false;
-	Archive::CompressionType compression = Archive::CompressionType::Uncompressed;
+	OP2Utility::Archive::CompressionType compression = OP2Utility::Archive::CompressionType::Uncompressed;
 };
 
 enum class ConsoleCommand


### PR DESCRIPTION
I took the approach of adding a namespace using statement in the .cpp files if OP2Utility calls were being made more than about once or twice. Open to discussion if that is not preferred.